### PR TITLE
Add new Mozilla-wide CoC template file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,15 @@
-Code of conduct
-===============
+# Community Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. For more details please see the [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/) and [Developer Etiquette Guidelines](https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
+This repository is governed by Mozilla's code of conduct and etiquette guidelines. 
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
+
+## How to Report
+For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
+
+<!--
+## Project Specific Etiquette
+
+In some cases, there will be additional project etiquette i.e.: (https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
+Please update for your project.
+-->


### PR DESCRIPTION
Mozilla has created a Mozilla standard Code of Conduct for GitHub repos.
More info later today in https://wiki.mozilla.org/WeeklyUpdates/2019-03-25#Speakers

The Mozilla template lives here: https://github.com/mozilla/repo-templates/blob/master/templates/CODE_OF_CONDUCT.md
Docs: https://wiki.mozilla.org/GitHub/Repository_Requirements

Do we want any optional text?