### PR TITLE
Create 005-javascript-style.md

### DIFF
--- a/ADRs/005-javascript-style.md
+++ b/ADRs/005-javascript-style.md
@@ -1,0 +1,33 @@
+Document Javascript code style guidelines and Use ESlint and Prettier across MDN
+
+
+|Status       | proposed <!--becomes accepted, rejected or superseded later-->|
+|-----------------|-----------------------------------------------------------|
+|**Proposed**     | 31 May 2019
+|**Accepted**     | (the date the proposal was accepted/rejected)
+|**Driver**       | Schalk Neethling
+|**Approver**     | TBD
+|**Consulted**    | MDN Team
+|**Informed**     | MDN Team
+
+### Decision
+
+Document JavaScript code style guidelines, and adopt Prettier and ESLint across all MDN codebases.
+
+### Context
+
+We have a number of repositories across the MDN organization that uses JavaScript. To ease 
+contributions, shorten pull requests review time, and ease transition between projects,
+it is suggested that we adopt a JavaScript code style guide across all projects inside the MDN org.
+
+To ensure that the guidlines are followed, it is also suggested that we utilise Prettier for formatting,
+and ESLint for linting across all projects via standard configurations.
+
+### Consequences
+
+We have a standard JavaScript code style across projects, and tools that enforce these standards. 
+
+### Alternatives Considered
+
+This is very norrowly scoped and suggests tools that are standard across the industry, so other options
+have not been explored.


### PR DESCRIPTION
Document Javascript code style guidelines and Use ESlint and Prettier across MDN

First stab at putting together an ADR for introducing a JavaScript code style guide as well as related tools. Please let me know your thoughts @peterbe @escattone @davidflanagan 