### PR TITLE
chore: minor typo fixes, add links to contrib docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-or-feature-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/content-or-feature-suggestion.yml
@@ -1,5 +1,5 @@
-name: New content or feature suggestions
-description: Use this template when suggestion new content or new features for MDN Web Docs
+name: New content or feature requests
+description: Proposals for new content or features on MDN Web Docs
 title: A short title that begins with a verb
 labels: ["content suggestion", "feature suggestion", "proposed"]
 assignees:
@@ -8,21 +8,15 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for your taking the time to put together this proposal for new content or a new feature on MDN Web Docs. Please note that we have a well defined process for handling these requests. Please read [TODO:](TODO:) for more information.
+        Thank you for taking the time to put together a proposal for new content or a feature on MDN Web Docs.
+        We have a well-defined process for handling these requests.
+        For more information, see our [Community Guidelines](https://developer.mozilla.org/en-US/docs/MDN/Community).
   - type: input
     attributes:
       label: Proposed
       description: Put today's date here.
     validations:
       required: true
-  - type: input
-    attributes:
-      label: Accepted/Rejected
-      description: For internal usage - the date the proposal was accepted/rejected
-  - type: input
-    attributes:
-      label: Accepted/Rejected by
-      description: For internal usage - Team who accepted/rejected the proposal
   - type: input
     attributes:
       label: Proposed by
@@ -44,18 +38,31 @@ body:
   - type: textarea
     attributes:
       label: Context
-      description: Provide all the context needed to understand the proposal and why it is needed. This should be at least a paragraph but can be as long as necessary.
+      description: |
+        Provide all the context needed to understand the proposal and why it is needed.
+        This should be at least a paragraph but can be as long as necessary.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Consequences
-      description: Describe the pros and cons of the proposed decision. Think about the people in the **Informed** line above. How will this decision affect them?
+      description: |
+        Describe the pros and cons of the proposed decision.
+        Think about the people in the **Informed** line above.
+        How will this decision affect them?
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Alternatives Considered
+      label: Alternatives
       description: Describe the research you did and the alternatives you considered before making this proposal.
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Accepted/Rejected
+      description: For internal usage - the date the proposal was accepted/rejected
+  - type: input
+    attributes:
+      label: Accepted/Rejected by
+      description: For internal usage - Team who accepted/rejected the proposal

--- a/.github/ISSUE_TEMPLATE/new-member-request.yml
+++ b/.github/ISSUE_TEMPLATE/new-member-request.yml
@@ -1,5 +1,5 @@
 name: New Member Request
-description: Use this template when requesting to become a member of an MDN Web Docs GitHub team
+description: Use this template to request to become a member of an MDN Web Docs GitHub team
 title: Requesting to become a member of the [team-name] team
 labels: ["team membership request"]
 assignees:
@@ -8,7 +8,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for your interest in becoming a member of an MDN Web Docs team. Please ensure that you have read what it means to be [part of a team](TBD) before continuing.
+        Thank you for your interest in becoming a member of an MDN Web Docs team.
+        Please ensure that you have read what it means to be [part of a team](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams) before continuing.
   - type: input
     attributes:
       label: Given name or GitHub username
@@ -16,13 +17,13 @@ body:
       required: true
   - type: input
     attributes:
-      label: GitHub profile link
+      label: Your GitHub profile link
       placeholder: https://github.com/<username>
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Links to contributions made to MDN Web Docs on GitHub
+      label: Links to contributions made to MDN Web Docs on GitHub.
       placeholder: For example https://github.com/mdn/yari/commits?author=schalkneethling
     validations:
       required: true
@@ -36,7 +37,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/mdn/mdn/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/mdn/mdn/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
@@ -44,9 +45,9 @@ body:
     id: terms
     attributes:
       label: Commit Access Requirements
-      description: By submitting this issue, you agree to Mozilla’s [Commit Access Requirements](https://www.mozilla.org/en-US/about/governance/policies/commit/requirements/)
+      description: By submitting this issue, you agree to Mozilla's [Commit Access Requirements](https://www.mozilla.org/en-US/about/governance/policies/commit/requirements/).
       options:
-        - label: I agree to follow Mozilla’s Commit Access Requirements
+        - label: I agree to follow Mozilla's Commit Access Requirements
           required: true
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/nominate-invited-expert.yml
+++ b/.github/ISSUE_TEMPLATE/nominate-invited-expert.yml
@@ -1,7 +1,7 @@
 name: Nominate an invited expert
 description: Use this template when nominating an invited expert.
 title: Nominating an invited expert for [technology topic]
-labels: ['invited-expert-nomination']
+labels: ["invited-expert-nomination"]
 assignees:
   - schalkneethling
 body:

--- a/.github/ISSUE_TEMPLATE/nominate-maintainer.yml
+++ b/.github/ISSUE_TEMPLATE/nominate-maintainer.yml
@@ -8,7 +8,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to nominate an individual to become a co-maintainer. Please ensure that you have read and understood the responsibilities of [a volunteer maintainer](TBD) before continuing.
+        Thank you for taking the time to nominate an individual to become a co-maintainer.
+        Please ensure that you have read and understood the responsibilities of [a volunteer maintainer](https://developer.mozilla.org/en-US/docs/MDN/Community/Pull_requests) before continuing.
   - type: input
     attributes:
       label: Given name or GitHub username
@@ -20,21 +21,23 @@ body:
       placeholder: https://github.com/<username>
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Repository URL
+      description: The URL of the repository this person will co-maintain.
+    validations:
+      required: true
   - type: textarea
     attributes:
-      label: Why are you nominating this individual?
-      description: Please provide a short description of why you are nominating this individual to become a co-maintainer of the repository.
+      label: Why are you nominating this person?
+      description: Tell us why you are nominating this person to become a co-maintainer of the repository.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Supporting evidence
-      description: Evidence to support the nomination. For example links to contributions as well as interactions with the larger community and partners. For example commiter links such as this one, https://github.com/mdn/yari/commits?author=schalkneethling
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: Repository URL
-      description: The URL of th repository this individual will be a co-maintainer of.
+      description: |
+        Provide evidence to support your nomination such as contributions and interactions with the community.
+          Links to [commit logs](https://github.com/mdn/yari/commits?author=schalkneethling) in a repository are also appropriate.
     validations:
       required: true


### PR DESCRIPTION
This PR cleans up some of the issue templates with typo fixes. Also adds links to contributor docs instead of placeholders.