### PR TITLE
chore: add contributor spotlight markdown file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -11,7 +11,7 @@ Please submit information for the person you are nominating in the sections list
 
 Tell us why you are nominating this person to become a spotlight contributor.
 
-## Supporting evidence (required)
+## Supporting evidence for nominating this person (required)
 
 Provide evidence to support your nomination such as contributions and interactions with the community.
 Links to [commit logs](https://github.com/mdn/yari/commits?author=schalkneethling) in a repository are also appropriate.

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -7,7 +7,7 @@ Please submit information for the person you are nominating in the sections list
 
 ## GitHub profile link (required)
 
-## Why are you nominating this person? (required)
+## Reason for nominating this person (required)
 
 Tell us why you are nominating this person to become a spotlight contributor.
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -1,6 +1,7 @@
 # Nominating [GitHub username] as a [role]
 
 Thank you for taking the time to nominate a fellow contributor. Make sure you read our [list of prerequisites](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams) for the relevant role before submitting a nomination.
+Please submit information for the person you are nominating in the sections listed below.
 
 ## GitHub username (required)
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -15,4 +15,4 @@ Tell us why you are nominating this person to become a spotlight contributor.
 Provide evidence to support your nomination such as contributions and interactions with the community.
 Links to [commit logs](https://github.com/mdn/yari/commits?author=schalkneethling) in a repository are also appropriate.
 
-> Remember, contributions to this repository should follow its [code of conduct](https://github.com/mdn/mdn/blob/29bea1130762ae227192561d72585a07250afe8f/CODE_OF_CONDUCT.md).
+> Remember, contributions to this repository should follow its [code of conduct](https://github.com/mdn/mdn/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -5,7 +5,7 @@ Please submit information for the person you are nominating in the sections list
 
 ## GitHub username of the nominee (required)
 
-## GitHub profile link (required)
+## GitHub profile link of the nominee (required)
 
 ## Reason for nominating this person (required)
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -3,7 +3,7 @@
 Thank you for taking the time to nominate a fellow contributor. Make sure you read our [list of prerequisites](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams) for the relevant role before submitting a nomination.
 Please submit information for the person you are nominating in the sections listed below.
 
-## GitHub username (required)
+## GitHub username of the nominee (required)
 
 ## GitHub profile link (required)
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -13,7 +13,7 @@ Tell us why you are nominating this person to become a spotlight contributor.
 
 ## Supporting evidence for nominating this person (required)
 
-Provide evidence to support your nomination such as contributions and interactions with the community.
-Links to [commit logs](https://github.com/mdn/yari/commits?author=schalkneethling) in a repository are also appropriate.
+Provide evidence to support your nomination. The supporting information can include a list of their contributions and interactions with the community.
+You can also provide links to [commit logs](https://github.com/mdn/yari/commits?author=schalkneethling).
 
 > Remember, contributions to this repository should follow its [code of conduct](https://github.com/mdn/mdn/blob/main/CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-template.md
@@ -1,0 +1,18 @@
+# Nominating [GitHub username] as a [role]
+
+Thank you for taking the time to nominate a fellow contributor. Make sure you read our [list of prerequisites](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams) for the relevant role before submitting a nomination.
+
+## GitHub username (required)
+
+## GitHub profile link (required)
+
+## Why are you nominating this person? (required)
+
+Tell us why you are nominating this person to become a spotlight contributor.
+
+## Supporting evidence (required)
+
+Provide evidence to support your nomination such as contributions and interactions with the community.
+Links to [commit logs](https://github.com/mdn/yari/commits?author=schalkneethling) in a repository are also appropriate.
+
+> Remember, contributions to this repository should follow its [code of conduct](https://github.com/mdn/mdn/blob/29bea1130762ae227192561d72585a07250afe8f/CODE_OF_CONDUCT.md).

--- a/spotlight-contributors/index.md
+++ b/spotlight-contributors/index.md
@@ -4,48 +4,56 @@ For more details on our spotlight contributor program, see our [community docume
 
 ## Archive of our spotlight contributors
 
+### Tanner Dolby
+April, 2022
+
+- [On GitHub](https://github.com/tannerdolby)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/tanner-dolby)
+
+### Onkar Ruikar
+May, 2022
+
+- [On GitHub](https://github.com/OnkarRuikar)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/onkar-ruikar)
+
+### Queen Vinyl Da.i'gyu-Kazotetsu
+June, 2022
+
+- [On GitHub](https://github.com/queengooborg)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/vinyl-da-i-gyu-kazotetsu)
+
+### Julien (Sphinx on the Internets)
+July, 2022
+
+- [On GitHub](https://github.com/SphinxKnight)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/sphinx)
+
 ### Carolyn Wu
 August, 2022
 
 - [On GitHub](https://github.com/cw118)
 - [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/cw118)
 
-### Michael Koch
-
-- [On GitHub](https://github.com/mikoMK)
-- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/michael-koch)
-
 ### Michał Niedziółka
+September, 2022
 
 - [On GitHub](https://github.com/NiedziolkaMichal)
 - [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/niedziolka-michal)
 
-### Onkar Ruikar
+### Michael Koch
+October, 2022
 
-- [On GitHub](https://github.com/OnkarRuikar)
-- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/onkar-ruikar)
-
-### Julien (Sphinx on the Internets)
-
-- [On GitHub](https://github.com/SphinxKnight)
-- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/sphinx)
-
-### Tanner Dolby
-
-- [On GitHub](https://github.com/tannerdolby)
-- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/tanner-dolby)
-
-### Queen Vinyl Da.i'gyu-Kazotetsu
-
-- [On GitHub](https://github.com/queengooborg)
-- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/vinyl-da-i-gyu-kazotetsu)
+- [On GitHub](https://github.com/mikoMK)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/michael-koch)
 
 ### YiTao Yin
+November, 2022
 
 - [On GitHub](https://github.com/yin1999)
 - [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/yitao-yin)
 
 ### Yuji
+Deceber, 2022
 
 - [On GitHub](https://github.com/YujiSoftware)
 - [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/yuji)

--- a/spotlight-contributors/index.md
+++ b/spotlight-contributors/index.md
@@ -1,4 +1,4 @@
-# MDN Web Docs Spotlight Contributors
+# MDN Web Docs spotlight contributors
 
 For more details on our spotlight contributor program, see our [community documentation](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams#spotlight_contributor).
 

--- a/spotlight-contributors/index.md
+++ b/spotlight-contributors/index.md
@@ -1,0 +1,50 @@
+# MDN Web Docs Spotlight Contributors
+
+For more details on our spotlight contributor program, see our [community documentation](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams#spotlight_contributor).
+
+## Spotlight Contributors
+
+### Carolyn Wu
+
+- [On GitHub](https://github.com/cw118)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/cw118)
+
+### Michael Koch
+
+- [On GitHub](https://github.com/mikoMK)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/mikoMK)
+
+### Michał Niedziółka
+
+- [On GitHub](https://github.com/NiedziolkaMichal)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/niedziolka-michal)
+
+### Onkar Ruikar
+
+- [On GitHub](https://github.com/OnkarRuikar)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/onkar-ruikar)
+
+### Julien (Sphinx on the Internets)
+
+- [On GitHub](https://github.com/SphinxKnight)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/sphinx)
+
+### Tanner Dolby
+
+- [On GitHub](https://github.com/tannerdolby)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/tanner-dolby)
+
+### Queen Vinyl Da.i'gyu-Kazotetsu
+
+- [On GitHub](https://github.com/queengooborg)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/vinyl-da-i-gyu-kazotetsu)
+
+### YiTao Yin
+
+- [On GitHub](https://github.com/yin1999)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/yitao-yin)
+
+### Yuji
+
+- [On GitHub](https://github.com/YujiSoftware)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/yuji)

--- a/spotlight-contributors/index.md
+++ b/spotlight-contributors/index.md
@@ -2,7 +2,7 @@
 
 For more details on our spotlight contributor program, see our [community documentation](https://developer.mozilla.org/en-US/docs/MDN/Community/Users_teams#spotlight_contributor).
 
-## Spotlight Contributors
+## Archive of our spotlight contributors
 
 ### Carolyn Wu
 

--- a/spotlight-contributors/index.md
+++ b/spotlight-contributors/index.md
@@ -5,6 +5,7 @@ For more details on our spotlight contributor program, see our [community docume
 ## Archive of our spotlight contributors
 
 ### Carolyn Wu
+August, 2022
 
 - [On GitHub](https://github.com/cw118)
 - [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/cw118)

--- a/spotlight-contributors/index.md
+++ b/spotlight-contributors/index.md
@@ -12,7 +12,7 @@ For more details on our spotlight contributor program, see our [community docume
 ### Michael Koch
 
 - [On GitHub](https://github.com/mikoMK)
-- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/mikoMK)
+- [On MDN Web Docs](https://developer.mozilla.org/en-US/community/spotlight/michael-koch)
 
 ### Michał Niedziółka
 


### PR DESCRIPTION
Adds spotlight contributor markdown file and a pull request template to use when nominating someone for a particular role.

fix #263
