### PR TITLE
chore: update issue template with browser status section

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-or-feature-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/content-or-feature-suggestion.yml
@@ -15,18 +15,11 @@ body:
       description: Please describe the content or feature you are proposing and why it is needed.
     validations:
       required: true
-  - type: dropdown
-    id: browser
+  - type: textarea
     attributes:
       label: Browser support
-      description: Is this feature available in a stable browser release?
-      multiple: true
-      options:
-        - Firefox
-        - Chrome
-        - Safari
+      description: Is this feature available in a stable browser release? If so, in which version is it supported? Adding links to browser implementation bugs or other documentation speeds up this process.
   - type: textarea
-    id: task-list
     attributes:
       label: Tasks
       description: What needs to be done to complete this task?

--- a/.github/ISSUE_TEMPLATE/content-or-feature-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/content-or-feature-suggestion.yml
@@ -6,22 +6,39 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to put together a proposal for adding/updating content or a website feature on MDN Web Docs.
-        We have a well-defined process for handling these requests.
-        For more information, see our [Community Guidelines](https://developer.mozilla.org/en-US/docs/MDN/Community).
+        Thank you for taking the time to put together a proposal for adding/updating content or a website feature on MDN Web Docs. We have a well-defined process for handling these requests which you can read about in our [Community Guidelines](https://developer.mozilla.org/en-US/docs/MDN/Community).
+
+        New or experimental web platform features must be supported in at least **one stable browser release** before documentation is published to MDN. For more information, see the [What we write](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/What_we_write#suggesting_content) and the [experimental technologies](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete) documentation.
   - type: textarea
     attributes:
       label: Proposal
       description: Please describe the content or feature you are proposing and why it is needed.
     validations:
       required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser support
+      description: Is this feature available in a stable browser release?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
   - type: textarea
     id: task-list
     attributes:
-      label: Task list
-      description: List the steps involved to complete this project.
+      label: Tasks
+      description: What needs to be done to complete this task?
       value: |
-        - [ ] 
+        - [ ]
+  - type: textarea
+    attributes:
+      label: Dependencies
+      description: |
+        Does this task depend on anything else to be completed first? Links to GitHub issues or pull requests are helpful.
+      value: |
+        - [ ]
   - type: textarea
     attributes:
       label: Additional information
@@ -30,9 +47,6 @@ body:
   - type: input
     attributes:
       label: Are you willing to support this work?
-      description: MDN Web Docs is an open source project and welcomes contributions. Please state whether you are willing to help with the proposed work and in what capacity; this can be undertaking the work or supporting with reviews and/or queries.
-  - type: textarea
-    attributes:
-      label: Depends on
-      description: |
-        Does this work depend on any other work to be complete before it can begin? (Please provide links to existing issues if possible).
+      description: >
+        MDN Web Docs is an open source project and welcomes contributions.
+        Let us know whether you are willing to help with the proposed work and in what capacity; this can be undertaking the task itself or supporting with reviews and/or feedback.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 ![github-profile](https://user-images.githubusercontent.com/10350960/166113119-629295f6-c282-42c9-9379-af2de5ad4338.png)
 
-Welcome to the `mdn` repository! This is the holding repository for core MDN team work. You can find an overview of the current projects being worked on [in the wiki](https://github.com/mdn/mdn/wiki). The [MDN teams public project board is here](https://github.com/orgs/mdn/projects/12/), where you can view current and upcoming tasks.
+Welcome to the `mdn` repository which we use to track MDN team work.
+The [MDN teams public projects are here](https://github.com/orgs/mdn/projects), where you can view current and upcoming tasks.
 
-This repository is also used for requests/applications and contains issue templates for the following procedures:
+This repository is also used for requests and contains issue templates for the following processes:
 
 - [Proposing new content or features for MDN Web Docs](https://github.com/mdn/mdn/issues/new/choose)
 - [Nominating an invited expert](https://github.com/mdn/mdn/issues/new/choose)


### PR DESCRIPTION
This PR adds <strike>an optional dropdown where the author can choose a browser if it's known that the requested feature is supported in one browser</strike> a textarea for authors to add implementation notes with links to bug trackers, if possible.

Also add links to criteria for inclusion and experimental status pages on MDN.