### PR TITLE
Add default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,8 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
+* @mdn/content-team @mdn/contractors
+
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering
 /SECURITY.md @mdn/engineering


### PR DESCRIPTION
Add Content-team and Contractors to CODEOWNERS for better collaboration on `mdn/mdn`
For all changes, refer to mdn/mdn/issues/807